### PR TITLE
:bug: fix(Validations): Fix typo and add new option in 'PENNCNB_INVALID'

### DIFF
--- a/flourish_child_validations/form_validators/brief_2_forms_validators.py
+++ b/flourish_child_validations/form_validators/brief_2_forms_validators.py
@@ -43,7 +43,7 @@ class Brief2SelfReportedFormsValidators(BaseFormValidator):
         super().clean()
         self.validate_other_specify(
             field='brief2_self_invalid_reason',
-            other_specify_field='other_brief2_self_invalid_reason',
+            other_specify_field='other_breif2_self_invalid_reason',
         )
 
         self.validate_other_specify(

--- a/flourish_child_validations/form_validators/child_penn_cnb_form_validator.py
+++ b/flourish_child_validations/form_validators/child_penn_cnb_form_validator.py
@@ -1,7 +1,7 @@
+from edc_constants.constants import NO, YES
 from edc_form_validators import FormValidator
 
 from .form_validator_mixin import ChildFormValidatorMixin
-from edc_constants.constants import NO, YES
 
 
 class ChildPennCNBFormValidator(ChildFormValidatorMixin, FormValidator):
@@ -25,8 +25,8 @@ class ChildPennCNBFormValidator(ChildFormValidatorMixin, FormValidator):
             field='testing_impacted',
             other_specify_field='impact_other')
 
-        fields = ['date_deployed', 'start_time', 'stop_time', 'testing_impacted',
-                  'claim_experience', 'staff_assisting']
+        fields = ['date_deployed', 'start_time', 'stop_time', 'claim_experience',
+                  'staff_assisting']
 
         for field in fields:
             self.required_if(


### PR DESCRIPTION
Corrected a typo in `brief_2_forms_validators.py`, changing the `other_specify_field` value from 'other_brief2_self_invalid_reason' to 'other_breif2_self_invalid_reason'. Also, added a new tuple ('no_impact', 'No Impact') in the 'PENNCNB_INVALID' list in `choices.py`. These changes were made to ensure accurate field names and cover all options for invalid reasons in the 'PENNCNB_INVALID' list.