### PR TITLE
refactor(validations): Refactored child TB screening form validator function



### DIFF
--- a/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
+++ b/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from edc_constants.constants import YES
 from edc_form_validators import FormValidator
 
@@ -25,6 +26,10 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
             field_other='other_test',
         )
 
+        self.required_if(YES,
+                         field='child_diagnosed_with_tb',
+                         field_required='child_on_tb_treatment')
+
         field_responses = {
             'chest_xray': 'chest_xray_results',
             'sputum_sample': 'sputum_sample_results',
@@ -33,13 +38,19 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
             'blood_test': 'blood_test_results',
         }
 
-        for field, response in field_responses.items():
-            self.m2m_required_if(
+        for response, field in field_responses.items():
+            self.required_if_m2m(
                 response,
                 m2m_field='tb_tests',
                 field=field,
             )
 
-        self.required_if(YES,
-                         field='child_diagnosed_with_tb',
-                         field_required='child_on_tb_treatment')
+    def required_if_m2m(self, response, field=None, m2m_field=None):
+        m2m_field = self.cleaned_data.get(m2m_field)
+        selected = {obj.short_name: obj.name for obj in m2m_field if
+                    m2m_field is not None}
+        if response:
+            if response not in selected and not self.cleaned_data.get(field):
+                message = {field: 'This field is applicable'}
+                self._errors.update(message)
+                raise ValidationError(message)

--- a/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
+++ b/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
@@ -1,4 +1,4 @@
-from edc_constants.constants import YES
+from edc_constants.constants import OTHER, YES
 from edc_form_validators import FormValidator
 
 from .form_validator_mixin import ChildFormValidatorMixin
@@ -21,6 +21,7 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
                          field_required='clinic_visit_date')
 
         self.m2m_other_specify(
+            OTHER,
             m2m_field='tb_tests',
             field_other='other_test',
         )

--- a/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
+++ b/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
@@ -20,31 +20,26 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
                          field='evaluated_for_tb',
                          field_required='clinic_visit_date')
 
-        self.validate_other_specify(
-            field='tb_tests',
-            other_specify_field='other_test',
+        self.m2m_other_specify(
+            m2m_field='tb_tests',
+            field_other='other_test',
         )
 
-        self.required_if('chest_xray',
-                         field='tb_tests',
-                         field_required='chest_xray_results')
+        field_responses = {
+            'chest_xray': 'chest_xray_results',
+            'sputum_sample': 'sputum_sample_results',
+            'urine_test': 'urine_test_results',
+            'skin_test': 'skin_test_results',
+            'blood_test': 'blood_test_results',
+        }
 
-        self.required_if('sputum_sample',
-                         field='tb_tests',
-                         field_required='sputum_sample_results')
+        for field, response in field_responses.items():
+            self.m2m_required_if(
+                response,
+                m2m_field='tb_tests',
+                field=field,
+            )
 
-        self.required_if('stool_sample',
-                         field='tb_tests',
-                         field_required='stool_sample_results')
-
-        self.required_if('urine_test',
-                         field='tb_tests',
-                         field_required='urine_test_results')
-
-        self.required_if('skin_test',
-                         field='tb_tests',
-                         field_required='skin_test_results')
-
-        self.required_if('blood_test',
-                         field='tb_tests',
-                         field_required='blood_test_results')
+        self.required_if(YES,
+                         field='child_diagnosed_with_tb',
+                         field_required='child_on_tb_treatment')

--- a/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
+++ b/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ValidationError
 from edc_constants.constants import YES
 from edc_form_validators import FormValidator
 
@@ -39,18 +38,8 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
         }
 
         for response, field in field_responses.items():
-            self.required_if_m2m(
+            self.m2m_other_specify(
                 response,
                 m2m_field='tb_tests',
-                field=field,
+                field_other=field,
             )
-
-    def required_if_m2m(self, response, field=None, m2m_field=None):
-        m2m_field = self.cleaned_data.get(m2m_field)
-        selected = {obj.short_name: obj.name for obj in m2m_field if
-                    m2m_field is not None}
-        if response:
-            if response not in selected and not self.cleaned_data.get(field):
-                message = {field: 'This field is applicable'}
-                self._errors.update(message)
-                raise ValidationError(message)

--- a/flourish_child_validations/tests/test_tb_screening_form_validator.py
+++ b/flourish_child_validations/tests/test_tb_screening_form_validator.py
@@ -1,0 +1,30 @@
+import unittest
+
+from django.core.exceptions import ValidationError
+from django.test import tag
+
+from flourish_child_validations.form_validators import ChildTBScreeningFormValidator
+
+
+class TestClass:
+    def __init__(self, name, short_name):
+        self.name = name
+        self.short_name = short_name
+
+
+@tag('child_tb_screening')
+class TestChildTBScreeningFormValidator(unittest.TestCase):
+    def test_required_if_m2m_response_no_field(self):
+        cleaned_data = {'test_m2m_field': []}  # Empty m2m field
+        instance = ChildTBScreeningFormValidator(cleaned_data=cleaned_data)
+        with self.assertRaises(ValidationError):
+            instance.required_if_m2m('response', field='test_field', m2m_field='test_m2m_field')
+
+    def test_required_if_m2m_response_with_field(self):
+        m2m_mock = [TestClass(name='name', short_name='response')]
+        cleaned_data = {'test_field': 'value', 'test_m2m_field': m2m_mock}
+        instance = ChildTBScreeningFormValidator(cleaned_data=cleaned_data)
+        try:
+            instance.required_if_m2m('response', field='test_field', m2m_field='test_m2m_field')
+        except ValidationError:
+            self.fail("required_if_m2m raised ValidationError unexpectedly!")


### PR DESCRIPTION
In this update, the 'tb_tests' validation functions in child_tb_screening_form_validator.py have been restructured for efficiency. Instead of multiple instances of 'required_if' for different fields, a dictionary containing each field and its respective response was implemented, simplifying and cleaning the code. The 'other_specify' function has also been refactored to 'm2m_other_specify'.