### PR TITLE
Remove 'child_tested_for_hiv' requirement in form validation



### DIFF
--- a/flourish_child_validations/form_validators/infant_hiv_testing_form_validation.py
+++ b/flourish_child_validations/form_validators/infant_hiv_testing_form_validation.py
@@ -18,12 +18,6 @@ class InfantHIVTestingFormValidator(ChildFormValidatorMixin, FormValidator):
         )
 
         self.required_if(
-            YES,
-            field='child_tested_for_hiv',
-            field_required='pref_location',
-        )
-
-        self.required_if(
             NO,
             field='child_tested_for_hiv',
             field_required='not_tested_reason',


### PR DESCRIPTION
The requirement for 'child_tested_for_hiv' field in the form validation of the InfantHIVTestingOther model has been removed. This change is necessary to enhance data entry flexibility and prevent unnecessary validation errors when 'child_tested_for_hiv' is not applicable