### PR TITLE
(testing): Add validation test for Infant ARV Exposure Form

### DIFF
--- a/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
+++ b/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
@@ -81,13 +81,15 @@ class InfantArvExposureFormValidator(ChildFormValidatorMixin,
                          field='arvs_specify',
                          field_required='arvs_specify_other')
 
-    def validate_nvp_cont_dosing(self):
-        nvp_cont_dosing = self.cleaned_data('nvp_cont_dosing')
-        sdnvp_after_birth = self.cleaned_data('sdnvp_after_birth')
+        self.validate_nvp_cont_dosing()
 
-        if (not (nvp_cont_dosing == UNKNOWN or nvp_cont_dosing == YES) and
-                sdnvp_after_birth == YES):
+    def validate_nvp_cont_dosing(self):
+        nvp_cont_dosing = self.cleaned_data.get('nvp_cont_dosing')
+        sdnvp_after_birth = self.cleaned_data.get('sdnvp_after_birth')
+
+        if (not (sdnvp_after_birth == UNKNOWN or sdnvp_after_birth == YES) and
+                nvp_cont_dosing == YES):
             raise ValidationError({
-                'nvp_cont_dosing': 'This Question can only be NO if the child did not  '
+                'nvp_cont_dosing': 'This Question should be NO if the child did not  '
                                    'received NVP after birth'
             })

--- a/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
+++ b/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
@@ -88,5 +88,6 @@ class InfantArvExposureFormValidator(ChildFormValidatorMixin,
         if (not (nvp_cont_dosing == UNKNOWN or nvp_cont_dosing == YES) and
                 sdnvp_after_birth == YES):
             raise ValidationError({
-                'nvp_cont_dosing': 'This Question can only be NO if the child did not '
+                'nvp_cont_dosing': 'This Question can only be NO if the child did not  '
+                                   'received NVP after birth'
             })

--- a/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
+++ b/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
@@ -87,9 +87,11 @@ class InfantArvExposureFormValidator(ChildFormValidatorMixin,
         nvp_cont_dosing = self.cleaned_data.get('nvp_cont_dosing')
         sdnvp_after_birth = self.cleaned_data.get('sdnvp_after_birth')
 
-        if (not (sdnvp_after_birth == UNKNOWN or sdnvp_after_birth == YES) and
-                nvp_cont_dosing == YES):
-            raise ValidationError({
-                'nvp_cont_dosing': 'This Question should be NO if the child did not  '
-                                   'received NVP after birth'
-            })
+        allowed_options = [YES, UNKNOWN]
+
+        if (sdnvp_after_birth not in allowed_options and nvp_cont_dosing in
+                allowed_options):
+            msg = {'nvp_cont_dosing': 'This Question should be NO if the child did not  '
+                                      'received NVP after birth'}
+            self._errors.update(msg)
+            raise ValidationError(msg)

--- a/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
+++ b/flourish_child_validations/form_validators/infant_arv_exposure_form_validation.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from edc_constants.constants import YES, UNKNOWN, NO, OTHER
+from edc_constants.constants import OTHER, UNKNOWN, YES
 from edc_form_validators import FormValidator
 
 from .crf_offstudy_form_validator import CrfOffStudyFormValidator
@@ -41,7 +41,7 @@ class InfantArvExposureFormValidator(ChildFormValidatorMixin,
                 and self.cleaned_data.get('azt_after_birth') == UNKNOWN):
             if self.cleaned_data.get('azt_additional_dose') != UNKNOWN:
                 msg = {'azt_additional_dose': 'If Q3 is \'Unknown\', '
-                       'this field must be \'Unknown.\''}
+                                              'this field must be \'Unknown.\''}
                 self._errors.update(msg)
                 raise ValidationError(msg)
         else:
@@ -80,3 +80,13 @@ class InfantArvExposureFormValidator(ChildFormValidatorMixin,
         self.required_if(OTHER,
                          field='arvs_specify',
                          field_required='arvs_specify_other')
+
+    def validate_nvp_cont_dosing(self):
+        nvp_cont_dosing = self.cleaned_data('nvp_cont_dosing')
+        sdnvp_after_birth = self.cleaned_data('sdnvp_after_birth')
+
+        if (not (nvp_cont_dosing == UNKNOWN or nvp_cont_dosing == YES) and
+                sdnvp_after_birth == YES):
+            raise ValidationError({
+                'nvp_cont_dosing': 'This Question can only be NO if the child did not '
+            })


### PR DESCRIPTION
This commit adds new test cases to enhance the test coverage of the Infant ARV Exposure Form's validation function. Specifically, it checks the correct validation for 'azt_within_72h' and 'snvp_dose_within_72h' fields as well as handles the case when 'nvp_cont_dosing' field is YES but 'sdnvp_after_birth' is NO. Also, the order of class and constant imports has been modified in the test script for better readability. Signed-off-by: nmunatsibw 