### PR TITLE
(tests, form validator update): Added validation for pending HIV test results



### DIFF
--- a/flourish_child_validations/form_validators/infant_hiv_testing_form_validation.py
+++ b/flourish_child_validations/form_validators/infant_hiv_testing_form_validation.py
@@ -1,6 +1,6 @@
 from django.forms import ValidationError
 from edc_constants.choices import NO, YES
-from edc_constants.constants import OTHER
+from edc_constants.constants import OTHER, PENDING
 from edc_form_validators import FormValidator
 
 from .form_validator_mixin import ChildFormValidatorMixin
@@ -87,11 +87,7 @@ class InfantHIVTestingAdminFormValidatorRepeat(ChildFormValidatorMixin,
             field_required='result_date_estimated',
         )
 
-        self.required_if(
-            YES,
-            field='results_received',
-            field_required='hiv_test_result',
-        )
+        self.validate_results_pending()
 
         self.validate_test_date()
 
@@ -102,3 +98,12 @@ class InfantHIVTestingAdminFormValidatorRepeat(ChildFormValidatorMixin,
         if child_test_date and received_date and child_test_date > received_date:
             raise ValidationError(
                 {'received_date': 'Received date cannot be before test date.'})
+
+    def validate_results_pending(self):
+        results_received = self.cleaned_data.get('results_received')
+        hiv_test_result = self.cleaned_data.get('hiv_test_result')
+        if hiv_test_result == PENDING and results_received == YES:
+            raise ValidationError(
+                {'hiv_test_result': 'HIV test result cannot be pending if results are '
+                                    'received.'}
+            )

--- a/flourish_child_validations/tests/test_infant_hiv_testing_form_validation.py
+++ b/flourish_child_validations/tests/test_infant_hiv_testing_form_validation.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.test import tag, TestCase
 from django.utils import timezone
 from edc_base import get_utcnow
-from edc_constants.constants import FEMALE, NEG, NO, OTHER, YES
+from edc_constants.constants import FEMALE, NEG, NO, OTHER, PENDING, YES
 
 from .models import Appointment, CaregiverChildConsent, ChildVisit, ListModel
 from .test_model_mixin import TestModelMixin
@@ -191,3 +191,17 @@ class TestHIVInfantTestingFormValidator(TestModelMixin, TestCase):
             cleaned_data=form_data)
         self.assertRaises(ValidationError, form_validator.validate)
         self.assertIn('test_visit', form_validator._errors)
+
+    def test_validate_results_pending(self):
+        form_data = {
+            'results_received': YES,
+            'received_date': get_utcnow(),
+            'result_date_estimated': NO,
+            'hiv_test_result': PENDING
+        }
+        form = InfantHIVTestingAdminFormValidatorRepeat(form_data)
+
+        with self.assertRaises(ValidationError) as cm:
+            form.clean()
+
+        self.assertIn('hiv_test_result', str(cm.exception))


### PR DESCRIPTION
The existing `InfantHIVTestingAdminFormValidatorRepeat` in the `flourish-child-validations` module underwent updates to check for pending HIV test results, throwing an error when necessary. The tests were subsequently adjusted to reflect these changes and to verify that the validation now successfully rejects pending results when the results are marked as received. Signed-off-by: nmunatsibw 