### PR TITLE
(refactor): Update exception handling in child_preg_testing_form_validator



### DIFF
--- a/flourish_child_validations/form_validators/child_preg_testing_form_validator.py
+++ b/flourish_child_validations/form_validators/child_preg_testing_form_validator.py
@@ -119,7 +119,7 @@ class ChildPregTestingFormValidator(ChildFormValidatorMixin, FormValidator):
         try:
             child_preg_testing = self.child_preg_testing_model_cls.objects.get(
                 child_visit=previous_visit)
-        except self.child_preg_testing_model.DoesNotExist:
+        except self.child_preg_testing_model_cls.DoesNotExist:
             return None
         else:
             return child_preg_testing.menarche_start_dt


### PR DESCRIPTION
The exception class name being caught has been updated in the try-except block inside the flourish_child_validations package. This change corrects a potential NameError exception, ensuring that program flow continues correctly when the child_preg_testing_model_cls instance doesn't exist. Signed-off-by: nmunatsibw 