### PR TITLE
(Feature): Add household TB diagnosis condition

### DIFF
--- a/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
+++ b/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
@@ -17,6 +17,12 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
                              field=field,
                              field_required=f'{field}_duration')
 
+        self.required_if(
+            YES,
+            field='household_diagnosed_with_tb',
+            field_required='evaluated_for_tb'
+        )
+
         self.required_if(YES,
                          field='evaluated_for_tb',
                          field_required='clinic_visit_date')


### PR DESCRIPTION


This commit introduces a new validator rule to the child TB screening form. Now, 'evaluated_for_tb' field becomes mandatory if 'household_diagnosed_with_tb' is marked as 'YES'. This helps in ensuring that a child is being evaluated for TB if a household member is diagnosed with TB. Signed-off-by: nmunatsibw