### PR TITLE
(delete): Remove unnecessary required_if condition in child_tb_screening_form_validator


### DIFF
--- a/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
+++ b/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
@@ -1,5 +1,5 @@
 from django.forms import ValidationError
-from edc_constants.constants import NO, OTHER, YES
+from edc_constants.constants import NO, NONE, OTHER, YES
 from edc_form_validators import FormValidator
 
 from .form_validator_mixin import ChildFormValidatorMixin
@@ -49,7 +49,7 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
         )
 
         self.m2m_other_specify(
-            'none',
+            NONE,
             m2m_field='tb_tests',
             field_other='child_diagnosed_with_tb',
         )

--- a/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
+++ b/flourish_child_validations/form_validators/child_tb_screening_form_validator.py
@@ -17,12 +17,6 @@ class ChildTBScreeningFormValidator(ChildFormValidatorMixin, FormValidator):
                              field=field,
                              field_required=f'{field}_duration')
 
-        self.required_if(
-            YES,
-            field='household_diagnosed_with_tb',
-            field_required='evaluated_for_tb'
-        )
-
         self.required_if(YES,
                          field='evaluated_for_tb',
                          field_required='clinic_visit_date')


### PR DESCRIPTION

The required_if condition that was previously checking if a household was diagnosed with TB and required 'evaluated_for_tb' field has been removed. This change was in the child_tb_screening_form_validator file. This condition was found to be unnecessary for our validation. Signed-off-by: nmunatsibw